### PR TITLE
ci: pin Xcode 26.2 for the GhosttyKit zig build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
         with:
           tool: just
 
+      # Zig 0.15.2 cannot parse the macOS SDK shipped with the runner's default
+      # Xcode (26.5), so it links without libSystem and the GhosttyKit build fails
+      # with undefined libc symbols. Pin Xcode 26.2 to match upstream Ghostty's
+      # toolchain for this Zig version.
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
       - name: Cache GhosttyKit
         id: cache-ghosttykit
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           tool: just
 
+      # Zig 0.15.2 cannot parse the macOS SDK shipped with the runner's default
+      # Xcode (26.5), so it links without libSystem and the GhosttyKit build fails
+      # with undefined libc symbols. Pin Xcode 26.2 to match upstream Ghostty's
+      # toolchain for this Zig version.
+      - name: Select Xcode 26.2
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+
       - name: Cache GhosttyKit
         id: cache-ghosttykit
         uses: actions/cache@v5


### PR DESCRIPTION
## Problem

CI on `main` is red at the **Build GhosttyKit** step (`just setup` → `zig build`). The linker emits a wall of undefined libc/libSystem symbols (`_abort`, `_malloc_size`, `__availability_version_check` via `___isPlatformVersionAtLeast`, `_dispatch_*`, etc.), referenced from Zig's own build runner (`build_zcu.o`) and `libcompiler_rt.a`. The build aborts with `GhosttyKit.xcframework not found after build`.

## Root cause

The job runs on `macos-26` and installs a bare Zig 0.15.2, relying on the runner's default Xcode. GitHub advanced the `macos-26` image default to **Xcode 26.5** (SDK 17F42). Zig 0.15.2 does its own macOS SDK parsing (reads `libSystem.tbd`) and cannot use the 26.5 SDK, so it links GhosttyKit without libSystem at all — producing the undefined-symbol wall. (`xcrun metal --version` still passes because xcrun itself is fine; only Zig's SDK handling breaks.)

This was latent: the `Build GhosttyKit` step only runs on a GhosttyKit cache miss, and the cache had been hitting since the last real build on 2026-05-12. The cache expired (GitHub evicts after ~7 days idle), so the first real build since then surfaced the broken SDK.

## Fix

Select **Xcode 26.2** before the build — the toolchain upstream Ghostty pins for this exact Zig 0.15.2 build (`sudo xcode-select -s /Applications/Xcode_26.2.app` appears in every Ghostty macOS CI job), and a version confirmed present on the `macos-26` image. Applied to both `ci.yml` and `release.yml`, since the release workflow runs the same GhosttyKit build and has the same latent failure.

## Verification

This PR's CI run is the verification: it rebuilds GhosttyKit from a cold cache on `macos-26` with Xcode 26.2 pinned. Green = root cause confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)